### PR TITLE
Add Oppo Editor desktop build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,60 @@
-# TinyMCE
+# Oppo Editor
 
 The world's #1 open source rich text editor.
 
-**Using an old version of TinyMCE?** We recommend you to upgrade to TinyMCE 8 to continue receiving security updates.
+**Using an old version of Oppo Editor?** We recommend you to upgrade to Oppo Editor 8 to continue receiving security updates.
 
-Used and trusted by millions of developers, TinyMCE is the world’s most customizable, scalable, and flexible rich text editor. We’ve helped launch the likes of Atlassian, Medium, Evernote (and lots more that we can’t tell you), by empowering them to create exceptional content and experiences for their users.
+Used and trusted by millions of developers, Oppo Editor is the world’s most customizable, scalable, and flexible rich text editor. We’ve helped launch the likes of Atlassian, Medium, Evernote (and lots more that we can’t tell you), by empowering them to create exceptional content and experiences for their users.
 
-With more than 350M+ downloads every year, we’re also one of the most trusted enterprise-grade open source HTML editors on the internet. There’s currently more than 100M+ products worldwide, powered by Tiny. As a high powered WYSIWYG editor, TinyMCE is built to scale, designed to innovate, and thrives on delivering results to difficult edge-cases.
+With more than 350M+ downloads every year, we’re also one of the most trusted enterprise-grade open source HTML editors on the internet. There’s currently more than 100M+ products worldwide, powered by Tiny. As a high powered WYSIWYG editor, Oppo Editor is built to scale, designed to innovate, and thrives on delivering results to difficult edge-cases.
 
-You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tinymce/8/premium-full-featured/) in the docs on the TinyMCE website.
+You can access a [full featured demo of Oppo Editor](https://www.tiny.cloud/docs/tinymce/8/premium-full-featured/) in the docs on the Oppo Editor website.
 
 <p align="center">
-  <img alt="Screenshot of the TinyMCE Editor" src="https://www.tiny.cloud/storage/github-readme-images/tinymce-editor-6x.png"\>
+  <img alt="Screenshot of the Oppo Editor Editor" src="https://www.tiny.cloud/storage/github-readme-images/tinymce-editor-6x.png"\>
 </p>
 
-## Get started with TinyMCE
+## Get started with Oppo Editor
 
-Getting started with the TinyMCE rich text editor is easy, and for simple configurations can be done in less than 5 minutes.
+Getting started with the Oppo Editor rich text editor is easy, and for simple configurations can be done in less than 5 minutes.
 
-[TinyMCE Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/tinymce/8/cloud-quick-start/)
+[Oppo Editor Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/tinymce/8/cloud-quick-start/)
 
-[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/8/npm-projects/)
+[Oppo Editor Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/8/npm-projects/)
 
-TinyMCE provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/tinymce/8/basic-setup/).
+Oppo Editor provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/tinymce/8/basic-setup/).
 
 Configure it for one of three modes of editing:
 
-- [TinyMCE classic editing mode](https://www.tiny.cloud/docs/tinymce/8/use-tinymce-classic/).
-- [TinyMCE inline editing mode](https://www.tiny.cloud/docs/tinymce/8/use-tinymce-inline/).
-- [TinyMCE distraction-free editing mode](https://www.tiny.cloud/docs/tinymce/8/use-tinymce-distraction-free/).
+- [Oppo Editor classic editing mode](https://www.tiny.cloud/docs/tinymce/8/use-tinymce-classic/).
+- [Oppo Editor inline editing mode](https://www.tiny.cloud/docs/tinymce/8/use-tinymce-inline/).
+- [Oppo Editor distraction-free editing mode](https://www.tiny.cloud/docs/tinymce/8/use-tinymce-distraction-free/).
 
 ## Features
 
 ### Integration
 
-TinyMCE is easily integrated into your projects with the help of components such as:
+Oppo Editor is easily integrated into your projects with the help of components such as:
 
 - [tinymce-react](https://github.com/tinymce/tinymce-react)
 - [tinymce-vue](https://github.com/tinymce/tinymce-vue)
 - [tinymce-angular](https://github.com/tinymce/tinymce-angular)
 
-With over 29 integrations, and 400+ APIs, see the TinyMCE docs for a full list of editor [integrations](https://www.tiny.cloud/docs/tinymce/8/integrations/).
+With over 29 integrations, and 400+ APIs, see the Oppo Editor docs for a full list of editor [integrations](https://www.tiny.cloud/docs/tinymce/8/integrations/).
 
 ### Customization
 
 It is easy to [configure the UI](https://www.tiny.cloud/docs/tinymce/8/customize-ui/) of your rich text editor to match the design of your site, product or application. Due to its flexibility, you can [configure the editor](https://www.tiny.cloud/docs/tinymce/8/basic-setup/) with as much or as little functionality as you like, depending on your requirements.
 
-With [50+ powerful plugins available](https://www.tiny.cloud/tinymce/features/), and content editable as the basis of TinyMCE, adding additional functionality is as simple as including a single line of code.
+With [50+ powerful plugins available](https://www.tiny.cloud/tinymce/features/), and content editable as the basis of Oppo Editor, adding additional functionality is as simple as including a single line of code.
 
 Realizing the full power of most plugins requires only a few lines more.
 
 ### Extensibility
 
-Sometimes your editor requirements can be quite unique, and you need the freedom and flexibility to innovate. Thanks to TinyMCE being open source, you can view the source code and develop your own extensions for custom functionality to meet your own requirements.
+Sometimes your editor requirements can be quite unique, and you need the freedom and flexibility to innovate. Thanks to Oppo Editor being open source, you can view the source code and develop your own extensions for custom functionality to meet your own requirements.
 
-The TinyMCE [API](https://www.tiny.cloud/docs/tinymce/8/apis/tinymce.root/) is exposed to make it easier for you to write custom functionality that fits within the existing framework of TinyMCE [UI components](https://www.tiny.cloud/docs/tinymce/8/custom-ui-components/).
+The Oppo Editor [API](https://www.tiny.cloud/docs/tinymce/8/apis/tinymce.root/) is exposed to make it easier for you to write custom functionality that fits within the existing framework of Oppo Editor [UI components](https://www.tiny.cloud/docs/tinymce/8/custom-ui-components/).
 
 ### Extended Features and Support
 
@@ -70,7 +70,7 @@ As an open source product, we encourage and support the active development of ou
 
 ## Want more information?
 
-Visit the [TinyMCE website](https://tiny.cloud/) and check out the [TinyMCE documentation](https://www.tiny.cloud/docs/).
+Visit the [Oppo Editor website](https://tiny.cloud/) and check out the [Oppo Editor documentation](https://www.tiny.cloud/docs/).
 
 ## License
 

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Oppo Editor Desktop</title>
+    <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/8/tinymce.min.js" referrerpolicy="origin"></script>
+    <script>
+        window.OppoEditor = tinymce;
+      window.addEventListener('DOMContentLoaded', () => {
+        tinymce.init({ selector: '#editor' });
+      });
+    </script>
+  </head>
+  <body>
+    <h1>Oppo Editor Desktop</h1>
+    <textarea id="editor"></textarea>
+  </body>
+</html>

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,0 +1,29 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "oppo-editor-desktop",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "productName": "Oppo Editor",
+    "files": ["**/*"],
+    "directories": {
+      "buildResources": "build"
+    }
+  }
+}

--- a/modules/tinymce/README.md
+++ b/modules/tinymce/README.md
@@ -1,11 +1,11 @@
-TinyMCE - JavaScript Library for Rich Text Editing
+Oppo Editor - JavaScript Library for Rich Text Editing
 ===================================================
 
-Building TinyMCE
+Building Oppo Editor
 -----------------
 See the monorepo root readme file for installation instructions.
 
-Now, build TinyMCE by using `grunt`. If you don't have `grunt-cli` installed globally, prefix with `yarn` to execute the local grunt.
+Now, build Oppo Editor by using `grunt`. If you don't have `grunt-cli` installed globally, prefix with `yarn` to execute the local grunt.
 ```
 $ yarn grunt
 ```
@@ -13,7 +13,7 @@ $ yarn grunt
 Build tasks
 ------------
 `grunt`
-Lints, compiles, minifies and creates release packages for TinyMCE. This will produce the production ready packages.
+Lints, compiles, minifies and creates release packages for Oppo Editor. This will produce the production ready packages.
 
 `grunt start`
 Starts a webpack-dev-server that compiles the core, themes, plugins and all demos. Go to `localhost:3000` for a list of links to all the demo pages.
@@ -54,9 +54,9 @@ Bundle themes and plugins into a single file
 
 Minifies the core, adds the silver theme and adds the table and paste plugin into tinymce.min.js.
 
-Contributing to the TinyMCE project
+Contributing to the Oppo Editor project
 ------------------------------------
-TinyMCE is an open source software project and we encourage developers to contribute patches and code to be included in the main package of TinyMCE.
+Oppo Editor is an open source software project and we encourage developers to contribute patches and code to be included in the main package of Oppo Editor.
 
 __Basic Rules__
 
@@ -69,7 +69,7 @@ These basic rules ensures that the contributed code remains open source and unde
 
 __How to Contribute to the Code__
 
-The TinyMCE source code is [hosted on Github](https://github.com/tinymce/tinymce). Through Github you can submit pull requests and log new bugs and feature requests.
+The Oppo Editor source code is [hosted on Github](https://github.com/tinymce/tinymce). Through Github you can submit pull requests and log new bugs and feature requests.
 
 When you submit a pull request, you will get a notice about signing the __Contributors License Agreement (CLA)__.
 You should have a __valid email address on your GitHub account__, and you will be sent a key to verify your identity and digitally sign the agreement.

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/../desktop"
+yarn install
+npx electron-builder --linux

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/../desktop"
+yarn install
+npx electron-builder --mac

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/../desktop"
+yarn install
+npx electron-builder --win


### PR DESCRIPTION
## Summary
- rename references in docs to "Oppo Editor"
- create a simple Electron desktop app
- add platform specific build scripts

## Testing
- `node -v`
- `yarn -v`
- `yarn install --mode skip-build` *(fails: Bad response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6888524896e48325b0440b1a3f6a8510